### PR TITLE
Formatting check & check-only pre-commit hook

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -5,4 +5,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: chartboost/ruff-action@v1
+      - name: lint
+        uses: chartboost/ruff-action@v1
+        with:
+          args: check --output-format=github .
+      - name: format
+        uses: chartboost/ruff-action@v1
+        with:
+          args: format .

--- a/pre-commit
+++ b/pre-commit
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+GIT_ROOT=$(git rev-parse --show-toplevel)
+cd "$GIT_ROOT" || exit
+
+run_ruff_on_staged() {
+    local operation=$1 # 'format' or 'check'
+    local staged_files
+    staged_files=$(git diff --cached --name-only --diff-filter=d)
+
+    local has_changes=0
+    for file in $staged_files; do
+        if [[ $file == *".py" ]]; then
+            if [ "$operation" == "format" ]; then
+                ruff format --diff "$file"
+            else
+                ruff check "$file"
+            fi
+
+            # Capture the exit status of ruff
+            local status=$?
+            if [ $status -ne 0 ]; then
+                has_changes=1
+            fi
+        fi
+    done
+
+    return $has_changes
+}
+
+# Check formatting of staged Python files
+if ! run_ruff_on_staged "format" ; then
+    echo "Ruff would make formatting changes. Please run 'ruff format' on the staged files and commit again."
+    exit 1
+fi
+
+# Lint staged Python files
+if ! run_ruff_on_staged "check" ; then
+    echo "Ruff linter found issues that need to be resolved. Please run 'ruff check' on the staged files and address the issues."
+    exit 1
+fi
+
+exit 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,24 +33,3 @@ dynamic = ["version"]
 [project.scripts]
 warnet = "warnet.server:run_server"
 warcli = "cli.main:cli"
-
-[tool.ruff]
-extend-exclude = ["src/test_framework/*.py"]
-line-length = 100
-indent-width = 4
-[tool.ruff.lint]
-select = [
-    # pycodestyle
-    "E",
-    # Pyflakes
-    "F",
-    # pyupgrade
-    "UP",
-    # flake8-bugbear
-    "B",
-    # flake8-simplify
-    "SIM",
-    # isort
-    "I",
-]
-ignore = ["E501"] # Line too long

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,54 @@
+extend-exclude = ["src/test_framework/*.py"]
+line-length = 100
+indent-width = 4
+
+[lint]
+select = [
+    # pycodestyle
+    "E",
+    # Pyflakes
+    "F",
+    # pyupgrade
+    "UP",
+    # flake8-bugbear
+    "B",
+    # flake8-simplify
+    "SIM",
+    # isort
+    "I",
+]
+ignore = ["E501"] # Line too long
+
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[format]
+# Like Black, use double quotes for strings.
+quote-style = "double"
+
+# Like Black, indent with spaces, rather than tabs.
+indent-style = "space"
+
+# Like Black, respect magic trailing commas.
+skip-magic-trailing-comma = false
+
+# Like Black, automatically detect the appropriate line ending.
+line-ending = "auto"
+
+# Enable auto-formatting of code examples in docstrings. Markdown,
+# reStructuredText code/literal blocks and doctests are all supported.
+#
+# This is currently disabled by default, but it is planned for this
+# to be opt-out in the future.
+docstring-code-format = false
+
+# Set the line length limit used when formatting code snippets in
+# docstrings.
+#
+# This only has an effect when the `docstring-code-format` setting is
+# enabled.
+docstring-code-line-length = "dynamic"

--- a/src/backends/compose/compose_backend.py
+++ b/src/backends/compose/compose_backend.py
@@ -51,7 +51,7 @@ class ComposeBackend(BackendInterface):
         super().__init__(config_dir)
         self.network_name = network_name
         self.client: docker.DockerClient = docker.from_env()
-        self._apiclient: docker.APIClient = docker.APIClient(base_url='unix://var/run/docker.sock')
+        self._apiclient: docker.APIClient = docker.APIClient(base_url="unix://var/run/docker.sock")
 
     def build(self) -> bool:
         command = ["docker", "compose", "build"]
@@ -139,7 +139,7 @@ class ComposeBackend(BackendInterface):
             case _:
                 return RunningStatus.PENDING
 
-    def exec_run( self, tank_index: int, service: ServiceType, cmd: str) -> str:
+    def exec_run(self, tank_index: int, service: ServiceType, cmd: str) -> str:
         c = self.get_container(tank_index, service)
         result = c.exec_run(cmd=cmd)
         if result.exit_code != 0:
@@ -194,9 +194,7 @@ class ComposeBackend(BackendInterface):
         # (which may include the internal port if connection is inbound)
         subdir = "/" if bitcoin_network == "main" else f"{bitcoin_network}/"
         base_dir = f"/root/.bitcoin/{subdir}message_capture"
-        dirs = self.exec_run(
-            a_index, ServiceType.BITCOIN, f"ls {base_dir}"
-        )
+        dirs = self.exec_run(a_index, ServiceType.BITCOIN, f"ls {base_dir}")
         dirs = dirs.splitlines()
         messages = []
         for dir_name in dirs:
@@ -365,7 +363,14 @@ class ComposeBackend(BackendInterface):
             # it's a git branch, building step is necessary
             repo, branch = tank.version.split("#")
             services[container_name]["image"] = f"{LOCAL_REGISTRY}:{branch}"
-            build_image(repo, branch, LOCAL_REGISTRY, branch, tank.DEFAULT_BUILD_ARGS + tank.build_args, arches="amd64")
+            build_image(
+                repo,
+                branch,
+                LOCAL_REGISTRY,
+                branch,
+                tank.DEFAULT_BUILD_ARGS + tank.build_args,
+                arches="amd64",
+            )
             self.copy_configs(tank)
         elif tank.image:
             # Pre-built custom image
@@ -511,7 +516,7 @@ class ComposeBackend(BackendInterface):
         Fetches the IPv4 address of a given container.
         """
         container_inspect = self.client.containers.get(container.id).attrs
-        return container_inspect['NetworkSettings']['Networks'][self.network_name]['IPAddress']
+        return container_inspect["NetworkSettings"]["Networks"][self.network_name]["IPAddress"]
 
     def get_container_health(self, container: Container):
         c_inspect = self._apiclient.inspect_container(container.name)

--- a/src/backends/kubernetes/kubernetes_backend.py
+++ b/src/backends/kubernetes/kubernetes_backend.py
@@ -78,7 +78,7 @@ class KubernetesBackend(BackendInterface):
         Read a file from inside a container
         """
         pod_name = self.get_pod_name(tank_index, service)
-        exec_command = ['sh', '-c', f'cat "{file_path}" | base64']
+        exec_command = ["sh", "-c", f'cat "{file_path}" | base64']
 
         resp = stream(
             self.client.connect_get_namespaced_pod_exec,
@@ -256,9 +256,7 @@ class KubernetesBackend(BackendInterface):
                 for file, outbound in [["msgs_recv.dat", False], ["msgs_sent.dat", True]]:
                     # Fetch the file contents from the container
                     file_path = f"{base_dir}/{dir_name}/{file}"
-                    blob = self.get_file(
-                        a_index, ServiceType.BITCOIN, f"{file_path}"
-                    )
+                    blob = self.get_file(a_index, ServiceType.BITCOIN, f"{file_path}")
                     # Parse the blob
                     json = parse_raw_messages(blob, outbound)
                     messages = messages + json

--- a/src/cli/graph.py
+++ b/src/cli/graph.py
@@ -17,9 +17,7 @@ def graph():
 @click.option("--version", type=str, default=DEFAULT_TAG)
 @click.option("--bitcoin_conf", type=Path)
 @click.option("--random", is_flag=True)
-def create(
-        number: int, outfile: Path, version: str, bitcoin_conf: Path, random: bool = False
-):
+def create(number: int, outfile: Path, version: str, bitcoin_conf: Path, random: bool = False):
     """
     Create a cycle graph with [n] nodes, and additionally include 7 extra random outbounds per node.
     Returns XML file as string with or without --outfile option
@@ -36,6 +34,7 @@ def create(
             },
         )
     )
+
 
 @graph.command()
 @click.argument("graph", type=Path)

--- a/src/warnet/server.py
+++ b/src/warnet/server.py
@@ -81,6 +81,7 @@ class Server:
         """
         Use flask to log traceback of unhandled excpetions
         """
+
         @self.app.errorhandler(Exception)
         def handle_exception(e):
             trace = traceback.format_exc()
@@ -147,7 +148,9 @@ class Server:
                     time_elapsed += check_interval
 
             # If we've reached here, the lock wasn't acquired in time
-            raise Exception(f"Failed to acquire the build lock within {timeout} seconds, aborting RPC.")
+            raise Exception(
+                f"Failed to acquire the build lock within {timeout} seconds, aborting RPC."
+            )
 
         self.app.before_request(log_request)
         self.app.before_request(build_check)
@@ -455,14 +458,13 @@ class Server:
             bio = BytesIO()
             nx.write_graphml(graph, bio, named_key_ids=True)
             xml_data = bio.getvalue()
-            return xml_data.decode('utf-8')
+            return xml_data.decode("utf-8")
         except Exception as e:
             msg = f"Error generating graph: {e}"
             self.logger.error(msg)
             raise ServerError(message=msg) from e
 
     def graph_validate(self, graph_path: str) -> str:
-
         schema = load_schema()
         with open(graph_path) as f:
             graph = nx.parse_graphml(f.read(), node_type=int)

--- a/src/warnet/utils.py
+++ b/src/warnet/utils.py
@@ -79,7 +79,9 @@ def handle_json(func):
             parsed_result = json.loads(result)
             return parsed_result
         except json.JSONDecodeError as e:
-            logging.error(f"JSON parsing error in {func.__name__}: {e}. Undecodable result: {result}")
+            logging.error(
+                f"JSON parsing error in {func.__name__}: {e}. Undecodable result: {result}"
+            )
             raise
         except Exception as e:
             logger.error(f"Error in {func.__name__}: {e}")
@@ -396,10 +398,7 @@ def default_bitcoin_conf_args() -> str:
     return " ".join(conf_args)
 
 
-def create_cycle_graph(
-        n: int, version: str, bitcoin_conf: str | None, random_version: bool
-):
-
+def create_cycle_graph(n: int, version: str, bitcoin_conf: str | None, random_version: bool):
     try:
         # Use nx.DiGraph() as base otherwise edges not always made in specific directions
         graph = nx.generators.cycle_graph(n, nx.DiGraph())
@@ -415,7 +414,9 @@ def create_cycle_graph(
         for _ in range(8):
             # Choose a random node to connect to
             # Make sure it's not the same node and they aren't already connected
-            potential_nodes = [ node for node in range(n) if n != node and not graph.has_edge(node, n) ]
+            potential_nodes = [
+                node for node in range(n) if n != node and not graph.has_edge(node, n)
+            ]
             if potential_nodes:
                 chosen_node = random.choice(potential_nodes)
                 graph.add_edge(node, chosen_node)
@@ -495,4 +496,3 @@ def validate_graph_schema(node_schema: dict, graph: nx.Graph):
     """
     for i in list(graph.nodes):
         validate(instance=graph.nodes[i], schema=node_schema)
-

--- a/test/build_branch_test.py
+++ b/test/build_branch_test.py
@@ -11,7 +11,7 @@ graph_file_path = Path(os.path.dirname(__file__)) / "data" / "build_v24_test.gra
 base = TestBase()
 base.start_server()
 print(base.warcli(f"network start {graph_file_path}"))
-base.wait_for_all_tanks_status(target="running", timeout=10*60)
+base.wait_for_all_tanks_status(target="running", timeout=10 * 60)
 
 print("\nWait for p2p connections")
 

--- a/test/ln_test.py
+++ b/test/ln_test.py
@@ -42,6 +42,8 @@ print("\nPaying invoice from node 0...")
 print(base.warcli(f"lncli 0 payinvoice -f {inv}"))
 
 print("Waiting for payment success")
+
+
 def check_invoices():
     invs = json.loads(base.warcli("lncli 2 listinvoices"))["invoices"]
     if len(invs) > 0 and invs[0]["state"] == "SETTLED":
@@ -49,6 +51,8 @@ def check_invoices():
         return True
     else:
         return False
+
+
 base.wait_for_predicate(check_invoices)
 
 base.stop_server()

--- a/test/rpc_test.py
+++ b/test/rpc_test.py
@@ -22,9 +22,7 @@ base.warcli("rpc 1 -generate 101")
 
 base.wait_for_predicate(lambda: "101" in base.warcli("rpc 0 getblockcount"))
 
-txid = base.warcli(
-    "rpc 1 sendtoaddress bcrt1qthmht0k2qnh3wy7336z05lu2km7emzfpm3wg46 0.1"
-)
+txid = base.warcli("rpc 1 sendtoaddress bcrt1qthmht0k2qnh3wy7336z05lu2km7emzfpm3wg46 0.1")
 
 base.wait_for_predicate(lambda: txid in base.warcli("rpc 0 getrawmempool"))
 


### PR DESCRIPTION
Now checks linting _and_ formatting using Ruff in the CI to ensure consistent style.

Also adds a pre-commit hook with can be installed with `cp pre-commit .git/hooks/pre-commit`. This will stop you from committing if the formatter or linter are unhappy. This could be annoying, until we get used to it? IDK...

Sorry @pinheadmz, but having the pre-commit hook auto format only the diffs as I mentioned was not really tractable at this time (someone is looking at it though: (``https://github.com/akaihola/darker/issues/521``). Ruff doesn't support it natively and I did try to think of some stashing and unstashing sequence, but I suspect this would cause conflicts for us when committing and be _extra annoying_.

This leaves formatting up to the committer. Ruff has many [integrations](https://docs.astral.sh/ruff/integrations/) though to make this more pleasant. I have neovim setup to format with ruff using `<leader>F` in my conform: (``https://github.com/willcl-ark/neovim/blob/master/lua/plugins/conform.lua``) plugin, and it seems VSCode is easy enough. Less sure about sublime...

WDYT? I would like homogenously-formatted code, but not at the expense of any frustration. Would also be happy to drop this and do a weekly `ruff format` pull (or just keep the status quo).